### PR TITLE
Issue fixed: CloseSidePane is not working on mobile window size

### DIFF
--- a/server/AppointmentPlanner/Shared/MainLayout.razor
+++ b/server/AppointmentPlanner/Shared/MainLayout.razor
@@ -161,6 +161,6 @@
 
     private void showSideBar()
     {
-        open = true;
+        open = !open;
     }
 }

--- a/wasm/AppointmentPlanner/Shared/MainLayout.razor
+++ b/wasm/AppointmentPlanner/Shared/MainLayout.razor
@@ -161,6 +161,6 @@
 
     private void showSideBar()
     {
-        open = true;
+        open = !open;
     }
 }


### PR DESCRIPTION
**Issue :** CloseSidePane is not working on mobile window size.

**Reason:** When clicking the button, we have only opened the sidebar, not handled the close case.

**Fix:** Resolved the issue by toggling the sidebar open true/false.